### PR TITLE
Fix uploading of files

### DIFF
--- a/blocks/easy_image_slider/javascript/build/block-edit.js
+++ b/blocks/easy_image_slider/javascript/build/block-edit.js
@@ -60,7 +60,7 @@
             },
             done: function (e, data) {
                 var target = data.newItem ? data.newItem : $(e.target);
-                $.get(getFileDetailDetailJson,{fID:data.result[0].fID}, function(file) {
+                $.get(getFileDetailDetailJson,{fID:(data.result.files || data.result)[0].fID}, function(file) {
                     fillSlideTemplate(file,target);
                 },'json');                 
             },


### PR DESCRIPTION
When uploading a file via ajax, the `fID` property should be read from `data.result.files[0].fID` and not from `data.result[0].fID`.
I don't know if with previous fileupload versions we should use `data.result` and not `data.result.files`, so this approach will work in every case.